### PR TITLE
Adjust Navigator Service to be abstract and concrete implementations

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,3 +1,7 @@
 include: package:lint/analysis_options.yaml
 analyzer:
   exclude: [lib/**.g.dart]
+
+linter:
+  rules:
+    - directives_ordering

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:fii_app/shared/interfaces/navigator_service_interface.dart';
-import 'package:fii_app/shared/services/navigator_service.dart';
+import 'package:fii_app/shared/services/app_navigator_service.dart';
 import 'package:fii_app/shared/stores/reit_store.dart';
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
@@ -8,7 +8,9 @@ import 'routes.dart';
 
 void main() {
   GetIt.I.registerLazySingleton(() => ReitStore());
-  GetIt.I.registerLazySingleton<INavigatorService>(() => NavigatorService());
+  GetIt.I.registerLazySingleton<NavigatorService>(
+    () => AppNavigatorService(),
+  );
 
   runApp(MyApp());
 }

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -3,5 +3,5 @@ import 'package:flutter/material.dart';
 import 'app.dart';
 
 Map<String, WidgetBuilder> appRoutes = {
-  '/': (_) => App(),
+  '/': (_) => const App(),
 };

--- a/lib/shared/hooks/use_navigator_service_hook.dart
+++ b/lib/shared/hooks/use_navigator_service_hook.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 
 NavigatorState? useNavigatorService() {
-  final currentState = GetIt.I.get<INavigatorService>().currentState;
+  final currentState = GetIt.I.get<NavigatorService>().currentState;
 
   if (currentState == null) {
     throw Exception("Error in accessing currentState on NavigatorService.");

--- a/lib/shared/interfaces/navigator_service_interface.dart
+++ b/lib/shared/interfaces/navigator_service_interface.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
-abstract class INavigatorService {
+abstract class NavigatorService {
+  late GlobalKey<NavigatorState> navigatorKey;
   NavigatorState? get currentState;
 }

--- a/lib/shared/services/app_navigator_service.dart
+++ b/lib/shared/services/app_navigator_service.dart
@@ -1,8 +1,9 @@
 import 'package:fii_app/shared/interfaces/navigator_service_interface.dart';
 import 'package:flutter/material.dart';
 
-class NavigatorService implements INavigatorService {
-  final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
+class AppNavigatorService implements NavigatorService {
+  @override
+  GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 
   @override
   NavigatorState? get currentState => navigatorKey.currentState;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -312,6 +312,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.2"
+  mockito:
+    dependency: "direct dev"
+    description:
+      name: mockito
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.0.13"
   package_config:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: fii_app
 description: A new Flutter project.
 
-publish_to: 'none' 
+publish_to: 'none'
 
 version: 1.0.0+1
 
@@ -14,7 +14,6 @@ dependencies:
   flutter_mobx: ^2.0.1
   get_it: ^7.2.0
   mobx: ^2.0.3
-  
 
 dev_dependencies:
   build_runner: ^2.0.6
@@ -22,6 +21,7 @@ dev_dependencies:
     sdk: flutter
   lint: ^1.0.0
   mobx_codegen: ^2.0.2
+  mockito: ^5.0.13
 
 flutter:
   uses-material-design: true

--- a/test/shared/stores/reit_store_test.dart
+++ b/test/shared/stores/reit_store_test.dart
@@ -3,16 +3,21 @@ import 'package:fii_app/shared/stores/reit_store.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
+import 'package:mockito/mockito.dart';
 
-class NavigatorServiceMock implements INavigatorService {
+class MockNavigatorService extends Mock implements NavigatorService {
   @override
   NavigatorState? get currentState => NavigatorState();
 }
 
 void main() {
-  test("ReitStore 'text' attribute should be 'Hello World'", () {
-    GetIt.I.registerSingleton<INavigatorService>(NavigatorServiceMock());
+  setUpAll(() {
+    GetIt.I.registerLazySingleton<NavigatorService>(
+      () => MockNavigatorService(),
+    );
+  });
 
+  test("ReitStore 'text' attribute should be 'Hello World'", () {
     final ReitStore reitStore = ReitStore();
     expect(reitStore.text, equals('Hello World'));
   });


### PR DESCRIPTION
O NavigatorService foi ajustado para ter uma implementação abstrata (interface) e uma implementação concreta (o NavigatorService de fato).

Com isso podemos injetar no GetIt a implementação concreta referenciada pela interface, e nos testes unitários realizar o Mock sem dificuldades. Também facilita caso queiramos trocar a implementação do Navigatorservice sem fazer muitas alterações na aplicação.