### PR TITLE
FA-19 - Criação do header na tela de lista de fundos (Home)

### DIFF
--- a/lib/core/errors/presentation_exceptions.dart
+++ b/lib/core/errors/presentation_exceptions.dart
@@ -1,0 +1,5 @@
+class InvalidPageException implements Exception {
+  final String message;
+
+  InvalidPageException(this.message);
+}

--- a/lib/core/navigation/routes.dart
+++ b/lib/core/navigation/routes.dart
@@ -2,5 +2,5 @@ import 'package:fii_app/modules/home/presentation/pages/home_page.dart';
 import 'package:flutter/material.dart';
 
 Map<String, WidgetBuilder> list = {
-  '/': (_) => const HomePage(),
+  '/': (_) => HomePage(),
 };

--- a/lib/core/presentation/components/header_app_bar.dart
+++ b/lib/core/presentation/components/header_app_bar.dart
@@ -1,0 +1,76 @@
+import 'package:fii_app/core/presentation/themes/app_colors.dart';
+import 'package:fii_app/core/presentation/themes/app_text_styles.dart';
+import 'package:flutter/material.dart';
+
+class HeaderAppBar extends StatelessWidget implements PreferredSizeWidget {
+  final String title;
+  final String? buttonLabel;
+  final void Function()? buttonOnPressed;
+  final bool showSearch;
+
+  @override
+  Size get preferredSize => showSearch
+      ? const Size.fromHeight(110)
+      : const Size.fromHeight(kToolbarHeight);
+
+  const HeaderAppBar({
+    Key? key,
+    required this.title,
+    this.buttonLabel,
+    this.buttonOnPressed,
+    this.showSearch = true,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      backgroundColor: AppColors.background,
+      elevation: 5.0,
+      shadowColor: AppColors.grey.withOpacity(0.2),
+      toolbarHeight: 110,
+      title: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                title,
+                style: AppTextStyles.header.copyWith(
+                  color: Colors.black,
+                ),
+              ),
+              if (buttonLabel != null && buttonOnPressed != null)
+                TextButton(
+                  onPressed: buttonOnPressed,
+                  child: Text(
+                    buttonLabel!,
+                    style: AppTextStyles.buttonLabel
+                        .copyWith(color: AppColors.primary),
+                  ),
+                ),
+            ],
+          ),
+          if (showSearch)
+            Container(
+              decoration: BoxDecoration(
+                color: AppColors.lightgray,
+                borderRadius: BorderRadius.circular(8.0),
+              ),
+              height: 40,
+              margin: const EdgeInsets.only(bottom: 10),
+              child: TextField(
+                decoration: InputDecoration(
+                  border: InputBorder.none,
+                  prefixIcon: const Icon(Icons.search),
+                  hintStyle: AppTextStyles.buttonText,
+                  contentPadding:
+                      const EdgeInsets.only(top: 6, bottom: 6, right: 10),
+                  hintText: 'Buscar',
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/core/presentation/themes/app_colors.dart
+++ b/lib/core/presentation/themes/app_colors.dart
@@ -5,4 +5,6 @@ abstract class AppColors {
   static const cardBackground = Color(0xFFE9DCD3);
   static const cardSpecialBackground = Color(0xFFE4AFA3);
   static const background = Color(0xFFFFFFFF);
+  static const lightgray = Color(0xFFF9F9F9);
+  static const grey = Color(0xFF6B6B6B);
 }

--- a/lib/core/presentation/themes/app_colors.dart
+++ b/lib/core/presentation/themes/app_colors.dart
@@ -3,6 +3,6 @@ import 'package:flutter/material.dart';
 abstract class AppColors {
   static const primary = Color(0xFF181697);
   static const cardBackground = Color(0xFFE9DCD3);
-  static const cardSpecicialBackground = Color(0xFFE4AFA3);
+  static const cardSpecialBackground = Color(0xFFE4AFA3);
   static const background = Color(0xFFFFFFFF);
 }

--- a/lib/core/presentation/themes/app_text_styles.dart
+++ b/lib/core/presentation/themes/app_text_styles.dart
@@ -1,3 +1,4 @@
+import 'package:fii_app/core/presentation/themes/app_colors.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
@@ -6,23 +7,50 @@ abstract class AppTextStyles {
   static final primaryFont = GoogleFonts.montserrat();
   static final secondaryFont = GoogleFonts.lexendDeca();
 
+  static final primaryFontWeightThin = FontWeight.w100;
+  static final primaryFontWeightExtraLight = FontWeight.w200;
+  static final primaryFontWeightLight = FontWeight.w300;
+  static final primaryFontWeightRegular = FontWeight.w400;
+  static final primaryFontWeightMedium = FontWeight.w500;
+  static final primaryFontWeightSemibold = FontWeight.w600;
+  static final primaryFontWeightBold = FontWeight.w700;
+  static final primaryFontWeightExtraBold = FontWeight.w800;
+  static final primaryFontWeightBlack = FontWeight.w900;
+
+  static final secondaryFontWeightRegular = FontWeight.w400;
+
+  static final header = primaryFont.copyWith(
+    fontSize: 20.0,
+    fontWeight: primaryFontWeightBold,
+  );
+
   static final title = primaryFont.copyWith(
     fontSize: 24.0,
-    fontWeight: FontWeight.bold,
+    fontWeight: primaryFontWeightBold,
   );
 
   static final subtitle = primaryFont.copyWith(
     fontSize: 18.0,
-    fontWeight: FontWeight.w500,
+    fontWeight: primaryFontWeightMedium,
   );
 
   static final captionHeader = primaryFont.copyWith(
     fontSize: 18.0,
-    fontWeight: FontWeight.w500,
+    fontWeight: primaryFontWeightMedium,
   );
 
   static final captionBody = primaryFont.copyWith(
     fontSize: 18.0,
-    fontWeight: FontWeight.w400,
+    fontWeight: primaryFontWeightRegular,
+  );
+
+  static final buttonLabel = primaryFont.copyWith(
+    fontSize: 14.0,
+    fontWeight: primaryFontWeightMedium,
+  );
+
+  static final buttonText = secondaryFont.copyWith(
+    fontSize: 13.0,
+    color: AppColors.grey,
   );
 }

--- a/lib/core/presentation/themes/app_text_styles.dart
+++ b/lib/core/presentation/themes/app_text_styles.dart
@@ -3,22 +3,25 @@ import 'package:google_fonts/google_fonts.dart';
 
 // ignore: avoid_classes_with_only_static_members
 abstract class AppTextStyles {
-  static final title = GoogleFonts.montserrat(
+  static final primaryFont = GoogleFonts.montserrat();
+  static final secondaryFont = GoogleFonts.lexendDeca();
+
+  static final title = primaryFont.copyWith(
     fontSize: 24.0,
     fontWeight: FontWeight.bold,
   );
 
-  static final subtitle = GoogleFonts.montserrat(
+  static final subtitle = primaryFont.copyWith(
     fontSize: 18.0,
     fontWeight: FontWeight.w500,
   );
 
-  static final captionHeader = GoogleFonts.montserrat(
+  static final captionHeader = primaryFont.copyWith(
     fontSize: 18.0,
     fontWeight: FontWeight.w500,
   );
 
-  static final captionBody = GoogleFonts.montserrat(
+  static final captionBody = primaryFont.copyWith(
     fontSize: 18.0,
     fontWeight: FontWeight.w400,
   );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:get_it/get_it.dart';
 import 'core/di/injections.dart' as di;
 import 'core/navigation/navigator_service.dart';
 import 'core/navigation/routes.dart' as routes;
+import 'core/presentation/themes/app_colors.dart';
 
 void main() {
   di.init();
@@ -16,7 +17,7 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'FII',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        primaryColor: AppColors.primary,
       ),
       navigatorKey: GetIt.I.get<NavigatorService>().navigatorKey,
       routes: routes.list,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,7 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'FII',
       theme: ThemeData(
+        primarySwatch: Colors.indigo,
         primaryColor: AppColors.primary,
       ),
       navigatorKey: GetIt.I.get<NavigatorService>().navigatorKey,

--- a/lib/modules/comparator/presentation/pages/comparator_page.dart
+++ b/lib/modules/comparator/presentation/pages/comparator_page.dart
@@ -1,0 +1,19 @@
+import 'package:fii_app/core/presentation/themes/app_colors.dart';
+import 'package:flutter/material.dart';
+
+class ComparatorPage extends StatelessWidget {
+  const ComparatorPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: AppColors.primary,
+        title: const Text("Comparator"),
+      ),
+      body: const Center(
+        child: Text("Comparator"),
+      ),
+    );
+  }
+}

--- a/lib/modules/home/presentation/components/page_loading.dart
+++ b/lib/modules/home/presentation/components/page_loading.dart
@@ -1,0 +1,15 @@
+import 'package:fii_app/core/presentation/themes/app_colors.dart';
+import 'package:flutter/material.dart';
+
+class PageLoading extends StatelessWidget {
+  const PageLoading({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: CircularProgressIndicator(
+        color: AppColors.primary,
+      ),
+    );
+  }
+}

--- a/lib/modules/home/presentation/models/app_page.dart
+++ b/lib/modules/home/presentation/models/app_page.dart
@@ -1,0 +1,19 @@
+import 'package:fii_app/modules/home/presentation/components/page_loading.dart';
+import 'package:flutter/material.dart';
+
+class AppPage {
+  late Widget Function() loading;
+  Widget Function() page;
+  bool isLoaded = false;
+
+  AppPage({
+    Widget Function()? loading,
+    required this.page,
+  }) {
+    if (loading != null) {
+      this.loading = loading;
+    } else {
+      this.loading = () => const PageLoading();
+    }
+  }
+}

--- a/lib/modules/home/presentation/pages/home_page.dart
+++ b/lib/modules/home/presentation/pages/home_page.dart
@@ -25,7 +25,7 @@ class HomePage extends StatelessWidget {
       ),
       bottomNavigationBar: Observer(
         builder: (_) => BottomNavigationBar(
-          backgroundColor: const Color(0xFFF9F9F9),
+          backgroundColor: AppColors.lightgray,
           unselectedFontSize: 13,
           selectedItemColor: AppColors.primary,
           selectedLabelStyle: AppTextStyles.secondaryFont,

--- a/lib/modules/home/presentation/pages/home_page.dart
+++ b/lib/modules/home/presentation/pages/home_page.dart
@@ -1,18 +1,54 @@
-import 'package:fii_app/modules/reit_list/presentation/pages/reit_list_page.dart';
+import 'package:fii_app/core/presentation/themes/app_colors.dart';
+import 'package:fii_app/core/presentation/themes/app_text_styles.dart';
+import 'package:fii_app/modules/home/presentation/stores/navigation_store.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
 
 class HomePage extends StatelessWidget {
-  const HomePage({Key? key}) : super(key: key);
+  final navigationStore = NavigationStore();
+
+  HomePage({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text("Home Page"),
-        automaticallyImplyLeading: false,
+      backgroundColor: AppColors.background,
+      body: Observer(
+        builder: (_) => IndexedStack(
+          index: navigationStore.currentPageIndex,
+          children: navigationStore.pages
+              .map<Widget>(
+                (page) => page.isLoaded ? page.page() : page.loading(),
+              )
+              .toList(),
+        ),
       ),
-      body: SingleChildScrollView(
-        child: ReitListPage(),
+      bottomNavigationBar: Observer(
+        builder: (_) => BottomNavigationBar(
+          backgroundColor: const Color(0xFFF9F9F9),
+          unselectedFontSize: 13,
+          selectedItemColor: AppColors.primary,
+          selectedLabelStyle: AppTextStyles.secondaryFont,
+          unselectedLabelStyle: AppTextStyles.secondaryFont,
+          currentIndex: navigationStore.currentPageIndex,
+          onTap: navigationStore.changePage,
+          items: const [
+            BottomNavigationBarItem(
+              icon: Icon(
+                Icons.home,
+                size: 28,
+              ),
+              label: 'Home',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(
+                Icons.compare_arrows_outlined,
+                size: 28,
+              ),
+              label: 'Comparador',
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/modules/home/presentation/stores/navigation_store.dart
+++ b/lib/modules/home/presentation/stores/navigation_store.dart
@@ -1,0 +1,34 @@
+import 'package:fii_app/core/errors/presentation_exceptions.dart';
+import 'package:fii_app/modules/comparator/presentation/pages/comparator_page.dart';
+import 'package:fii_app/modules/home/presentation/models/app_page.dart';
+import 'package:fii_app/modules/reit_list/presentation/pages/reit_list_page.dart';
+import 'package:mobx/mobx.dart';
+part 'navigation_store.g.dart';
+
+class NavigationStore = _NavigationStoreBase with _$NavigationStore;
+
+abstract class _NavigationStoreBase with Store {
+  @observable
+  List<AppPage> pages = [
+    AppPage(page: () => ReitListPage()),
+    AppPage(page: () => const ComparatorPage()),
+  ];
+
+  @observable
+  int currentPageIndex = 0;
+
+  _NavigationStoreBase() {
+    pages[currentPageIndex].isLoaded = true;
+  }
+
+  @action
+  int changePage(int index) {
+    if (index < pages.length) {
+      pages[index].isLoaded = true;
+      return currentPageIndex = index;
+    }
+
+    throw InvalidPageException(
+        'No page with index $index was found on pages list');
+  }
+}

--- a/lib/modules/home/presentation/stores/navigation_store.g.dart
+++ b/lib/modules/home/presentation/stores/navigation_store.g.dart
@@ -1,0 +1,64 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'navigation_store.dart';
+
+// **************************************************************************
+// StoreGenerator
+// **************************************************************************
+
+// ignore_for_file: non_constant_identifier_names, unnecessary_brace_in_string_interps, unnecessary_lambdas, prefer_expression_function_bodies, lines_longer_than_80_chars, avoid_as, avoid_annotating_with_dynamic
+
+mixin _$NavigationStore on _NavigationStoreBase, Store {
+  final _$pagesAtom = Atom(name: '_NavigationStoreBase.pages');
+
+  @override
+  List<AppPage> get pages {
+    _$pagesAtom.reportRead();
+    return super.pages;
+  }
+
+  @override
+  set pages(List<AppPage> value) {
+    _$pagesAtom.reportWrite(value, super.pages, () {
+      super.pages = value;
+    });
+  }
+
+  final _$currentPageIndexAtom =
+      Atom(name: '_NavigationStoreBase.currentPageIndex');
+
+  @override
+  int get currentPageIndex {
+    _$currentPageIndexAtom.reportRead();
+    return super.currentPageIndex;
+  }
+
+  @override
+  set currentPageIndex(int value) {
+    _$currentPageIndexAtom.reportWrite(value, super.currentPageIndex, () {
+      super.currentPageIndex = value;
+    });
+  }
+
+  final _$_NavigationStoreBaseActionController =
+      ActionController(name: '_NavigationStoreBase');
+
+  @override
+  int changePage(int index) {
+    final _$actionInfo = _$_NavigationStoreBaseActionController.startAction(
+        name: '_NavigationStoreBase.changePage');
+    try {
+      return super.changePage(index);
+    } finally {
+      _$_NavigationStoreBaseActionController.endAction(_$actionInfo);
+    }
+  }
+
+  @override
+  String toString() {
+    return '''
+pages: ${pages},
+currentPageIndex: ${currentPageIndex}
+    ''';
+  }
+}

--- a/lib/modules/reit_list/presentation/pages/reit_list_page.dart
+++ b/lib/modules/reit_list/presentation/pages/reit_list_page.dart
@@ -1,3 +1,4 @@
+import 'package:fii_app/core/presentation/components/header_app_bar.dart';
 import 'package:fii_app/core/presentation/themes/app_colors.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
@@ -22,9 +23,11 @@ class ReitListPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: AppColors.primary,
-        title: const Text("Home"),
+      backgroundColor: AppColors.background,
+      appBar: HeaderAppBar(
+        title: 'Fundos Imobiliários',
+        buttonLabel: 'Ver todos',
+        buttonOnPressed: () {},
       ),
       body: SingleChildScrollView(
         child: Container(

--- a/lib/modules/reit_list/presentation/pages/reit_list_page.dart
+++ b/lib/modules/reit_list/presentation/pages/reit_list_page.dart
@@ -1,3 +1,4 @@
+import 'package:fii_app/core/presentation/themes/app_colors.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:get_it/get_it.dart';
@@ -20,52 +21,60 @@ class ReitListPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.all(16),
-      child: Column(
-        children: [
-          Center(
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                ElevatedButton(
-                  onPressed: reitListStore.loadReitList,
-                  child: const Text(
-                    'Listar',
-                  ),
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: AppColors.primary,
+        title: const Text("Home"),
+      ),
+      body: SingleChildScrollView(
+        child: Container(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            children: [
+              Center(
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    ElevatedButton(
+                      onPressed: reitListStore.loadReitList,
+                      child: const Text(
+                        'Listar',
+                      ),
+                    ),
+                    ElevatedButton(
+                      onPressed: () => _showOrderingBottomSheet(context),
+                      child: const Text(
+                        'Ordenar',
+                      ),
+                    ),
+                  ],
                 ),
-                ElevatedButton(
-                  onPressed: () => _showOrderingBottomSheet(context),
-                  child: const Text(
-                    'Ordenar',
-                  ),
-                ),
-              ],
-            ),
+              ),
+              const SizedBox(height: 8),
+              Observer(
+                builder: (_) {
+                  if (reitListStore.isLoading) {
+                    return const Center(
+                      child: CircularProgressIndicator(),
+                    );
+                  }
+
+                  if (reitListStore.hasError) {
+                    return Center(
+                      child: Text(reitListStore.errorMessage),
+                    );
+                  }
+
+                  return Column(
+                    children: reitListStore.sortedReits
+                        .map((reit) => ReitCardComponent(reit: reit))
+                        .toList(),
+                  );
+                },
+              )
+            ],
           ),
-          const SizedBox(height: 8),
-          Observer(
-            builder: (_) {
-              if (reitListStore.isLoading) {
-                return const Center(
-                  child: CircularProgressIndicator(),
-                );
-              }
-
-              if (reitListStore.hasError) {
-                return Center(
-                  child: Text(reitListStore.errorMessage),
-                );
-              }
-
-              return Column(
-                children: reitListStore.sortedReits
-                    .map((reit) => ReitCardComponent(reit: reit))
-                    .toList(),
-              );
-            },
-          )
-        ],
+        ),
       ),
     );
   }

--- a/test/modules/home/presentation/stores/navigation_store_test.dart
+++ b/test/modules/home/presentation/stores/navigation_store_test.dart
@@ -1,0 +1,52 @@
+import 'package:fii_app/core/errors/presentation_exceptions.dart';
+import 'package:fii_app/modules/home/presentation/stores/navigation_store.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late NavigationStore navigationStore;
+
+  setUp(() {
+    navigationStore = NavigationStore();
+  });
+
+  group('constructor', () {
+    test('should set [isLoaded] from current page to true', () {
+      final currentPage = navigationStore.currentPageIndex;
+      expect(navigationStore.pages[currentPage].isLoaded, true);
+    });
+  });
+
+  group('changePage', () {
+    test('should set [currentPageIndex] to the new page index', () {
+      const newPage = 1;
+      navigationStore.changePage(newPage);
+
+      expect(navigationStore.currentPageIndex, newPage);
+    });
+
+    test('should set [isLoaded] from the new page to true', () {
+      const newPage = 1;
+      navigationStore.changePage(newPage);
+
+      expect(navigationStore.pages[newPage].isLoaded, true);
+    });
+
+    test(
+        'should not change [isLoaded] from pages that have not been changed to',
+        () {
+      const newPage = 0;
+      navigationStore.changePage(newPage);
+
+      expect(navigationStore.pages[1].isLoaded, false);
+    });
+
+    test(
+        'should throw [InvalidPageException] when page with provided index does not exist',
+        () {
+      const newPage = 10;
+
+      expect(() => navigationStore.changePage(newPage),
+          throwsA(isA<InvalidPageException>()));
+    });
+  });
+}


### PR DESCRIPTION
Criado header reutilizável na tela de lista de fundos, contendo:
- Título da página
- Botão "ver todos"
- Campo de texto para busca

![image](https://user-images.githubusercontent.com/5016325/129371297-8c7e91b8-b77b-4a4a-9d18-83284f1bfb64.png)
