### PR TITLE
FA-40 - Criar splash screen não-nativa (Flutter)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:fii_app/modules/splash_screen/presentation/pages/splash_screen_page.dart';
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 
@@ -28,14 +29,7 @@ class MyApp extends StatelessWidget {
             routes: routes.list,
           );
         } else {
-          return const MaterialApp(
-            title: "FII",
-            home: Scaffold(
-              body: Center(
-                child: CircularProgressIndicator(),
-              ),
-            ),
-          );
+          return const SplashScreenPage();
         }
       },
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,7 +20,7 @@ class MyApp extends StatelessWidget {
       builder: (BuildContext context, AsyncSnapshot snapshot) {
         if (snapshot.hasData) {
           return MaterialApp(
-            title: 'FII',
+            title: 'Meu Fundo Imobiliário',
             theme: ThemeData(
               primarySwatch: Colors.blue,
               primaryColor: AppColors.primary,

--- a/lib/modules/splash_screen/presentation/pages/splash_screen_page.dart
+++ b/lib/modules/splash_screen/presentation/pages/splash_screen_page.dart
@@ -1,0 +1,23 @@
+import 'package:fii_app/core/presentation/themes/app_colors.dart';
+import 'package:flutter/material.dart';
+
+class SplashScreenPage extends StatelessWidget {
+  const SplashScreenPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      home: Scaffold(
+        backgroundColor: AppColors.primary,
+        body: Center(
+          child: Padding(
+            padding: EdgeInsets.all(32.0),
+            child: Image(
+              image: AssetImage('assets/images/icons/splash_icon.png'),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/modules/splash_screen/presentation/pages/splash_screen_page.dart
+++ b/lib/modules/splash_screen/presentation/pages/splash_screen_page.dart
@@ -7,6 +7,7 @@ class SplashScreenPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const MaterialApp(
+      title: 'Meu Fundo Imobiliário',
       home: Scaffold(
         backgroundColor: AppColors.primary,
         body: Center(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,8 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+  assets:
+    - assets/images/icons/
 
 flutter_icons:
   android: "launcher_icon"


### PR DESCRIPTION
Criada splash screen não-nativa e sim no próprio Flutter, pois agora o app precisa de um tempo de loading para carregar todas as dependências.