### PR TITLE
FA-42 - Refatoração para melhorar error handling e responsability

### DIFF
--- a/lib/core/errors/failures.dart
+++ b/lib/core/errors/failures.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 
-abstract class Failure extends Equatable {
+class Failure extends Equatable {
   final String? message;
   final Exception? exception;
 

--- a/lib/core/presentation/stores/reit_list_store.dart
+++ b/lib/core/presentation/stores/reit_list_store.dart
@@ -29,21 +29,6 @@ abstract class _ReitListStoreBase with Store {
   @computed
   int get totalReits => reits.length;
 
-  final sortOptions = [
-    const ReitListSortOption(
-      label: "Patrimônio Liquído",
-      type: ReitListSortOptionType.netWorth,
-    ),
-    const ReitListSortOption(
-      label: "Dividend Yield Atual",
-      type: ReitListSortOptionType.currentDividendYield,
-    ),
-    const ReitListSortOption(
-      label: "Quantidade de Ativos",
-      type: ReitListSortOptionType.assetsAmount,
-    ),
-  ];
-
   @action
   Future<void> loadReitList() async {
     try {

--- a/lib/modules/reit_list/data/repositories/default_reit_list_settings_repository.dart
+++ b/lib/modules/reit_list/data/repositories/default_reit_list_settings_repository.dart
@@ -1,3 +1,5 @@
+import 'package:dartz/dartz.dart';
+import 'package:fii_app/core/errors/failures.dart';
 import 'package:fii_app/modules/reit_list/data/datasources/local_reit_list_settings_data_source.dart';
 import 'package:fii_app/modules/reit_list/domain/entities/reit_list_sort_option.dart';
 import 'package:fii_app/modules/reit_list/domain/repositories/reit_list_settings_repository.dart';
@@ -28,8 +30,24 @@ class DefaultReitListSettingsRepository implements ReitListSettingsRepository {
   }
 
   @override
-  Future<bool> saveEnabledLists(List<ReitListSortOptionType> lists) =>
-      localDatasource.saveEnabledLists(lists);
+  Future<Either<Failure, bool>> saveEnabledLists(
+      List<ReitListSortOptionType> lists) async {
+    try {
+      final saved = await localDatasource.saveEnabledLists(lists);
+
+      if (!saved) {
+        return Left(
+          UnexpectedFailure(
+            message: "Unable to save enabled lists on local datasource.",
+          ),
+        );
+      }
+
+      return Right(saved);
+    } on Exception catch (exception) {
+      return Left(LocalStorageFailure(exception: exception));
+    }
+  }
 
   @override
   int getListLimit() {
@@ -42,5 +60,21 @@ class DefaultReitListSettingsRepository implements ReitListSettingsRepository {
   }
 
   @override
-  Future<bool> saveListLimit(int limit) => localDatasource.saveListLimit(limit);
+  Future<Either<Failure, bool>> saveListLimit(int limit) async {
+    try {
+      final saved = await localDatasource.saveListLimit(limit);
+
+      if (!saved) {
+        return Left(
+          UnexpectedFailure(
+            message: "Unable to save list limit on local datasource.",
+          ),
+        );
+      }
+
+      return Right(saved);
+    } on Exception catch (exception) {
+      return Left(LocalStorageFailure(exception: exception));
+    }
+  }
 }

--- a/lib/modules/reit_list/domain/repositories/reit_list_settings_repository.dart
+++ b/lib/modules/reit_list/domain/repositories/reit_list_settings_repository.dart
@@ -1,9 +1,12 @@
+import 'package:dartz/dartz.dart';
+import 'package:fii_app/core/errors/failures.dart';
 import 'package:fii_app/modules/reit_list/domain/entities/reit_list_sort_option.dart';
 
 abstract class ReitListSettingsRepository {
   Future<List<ReitListSortOptionType>> getEnabledLists();
-  Future<bool> saveEnabledLists(List<ReitListSortOptionType> lists);
+  Future<Either<Failure, bool>> saveEnabledLists(
+      List<ReitListSortOptionType> lists);
 
   int getListLimit();
-  Future<bool> saveListLimit(int limit);
+  Future<Either<Failure, bool>> saveListLimit(int limit);
 }

--- a/lib/modules/reit_list/domain/usecases/save_enabled_lists.dart
+++ b/lib/modules/reit_list/domain/usecases/save_enabled_lists.dart
@@ -8,13 +8,6 @@ class SaveEnabledLists {
 
   SaveEnabledLists({required this.reitListSettingsRepository});
 
-  Future<Either<Failure, bool>> call(List<ReitListSortOptionType> lists) async {
-    final save = await reitListSettingsRepository.saveEnabledLists(lists);
-
-    if (save) {
-      return const Right(true);
-    } else {
-      return Left(LocalStorageFailure());
-    }
-  }
+  Future<Either<Failure, bool>> call(List<ReitListSortOptionType> lists) =>
+      reitListSettingsRepository.saveEnabledLists(lists);
 }

--- a/lib/modules/reit_list/domain/usecases/save_list_limit.dart
+++ b/lib/modules/reit_list/domain/usecases/save_list_limit.dart
@@ -7,13 +7,6 @@ class SaveListLimit {
 
   SaveListLimit({required this.reitListSettingsRepository});
 
-  Future<Either<Failure, bool>> call(int limit) async {
-    final save = await reitListSettingsRepository.saveListLimit(limit);
-
-    if (save) {
-      return const Right(true);
-    } else {
-      return Left(LocalStorageFailure());
-    }
-  }
+  Future<Either<Failure, bool>> call(int limit) =>
+      reitListSettingsRepository.saveListLimit(limit);
 }

--- a/lib/modules/reit_list/presentation/components/reit_list_settings_bottom_sheet_component.dart
+++ b/lib/modules/reit_list/presentation/components/reit_list_settings_bottom_sheet_component.dart
@@ -32,7 +32,7 @@ class ReitListSettingsBottomSheetComponent extends StatelessWidget {
             return Wrap(
               spacing: 5,
               runSpacing: 10,
-              children: reitListStore.sortOptions
+              children: reitListSettingsStore.sortOptions
                   .map(
                     (option) => FilterChipComponent(
                       label: option.label,

--- a/lib/modules/reit_list/presentation/pages/reit_list_page.dart
+++ b/lib/modules/reit_list/presentation/pages/reit_list_page.dart
@@ -57,7 +57,8 @@ class ReitListPage extends StatelessWidget {
               return CustomScrollView(
                 slivers: reitListSettingsStore.enabledLists
                     .map<List<Widget>>((enabledList) {
-                  final sortOption = reitListStore.sortOptions.singleWhere(
+                  final sortOption =
+                      reitListSettingsStore.sortOptions.singleWhere(
                     (item) => item.type == enabledList,
                   );
 

--- a/lib/modules/reit_list/presentation/stores/reit_list_settings_store.dart
+++ b/lib/modules/reit_list/presentation/stores/reit_list_settings_store.dart
@@ -24,6 +24,21 @@ abstract class _ReitListSettingsStoreBase with Store {
 
   int maxLoadingLimit = 5;
 
+  final sortOptions = [
+    const ReitListSortOption(
+      label: "Patrimônio Liquído",
+      type: ReitListSortOptionType.netWorth,
+    ),
+    const ReitListSortOption(
+      label: "Dividend Yield Atual",
+      type: ReitListSortOptionType.currentDividendYield,
+    ),
+    const ReitListSortOption(
+      label: "Quantidade de Ativos",
+      type: ReitListSortOptionType.assetsAmount,
+    ),
+  ];
+
   _ReitListSettingsStoreBase({
     required this.getEnabledLists,
     required this.saveEnabledLists,

--- a/test/modules/reit_list/data/repositories/default_reit_list_settings_repository_test.dart
+++ b/test/modules/reit_list/data/repositories/default_reit_list_settings_repository_test.dart
@@ -1,3 +1,4 @@
+import 'package:dartz/dartz.dart';
 import 'package:fii_app/modules/reit_list/data/datasources/local_reit_list_settings_data_source.dart';
 import 'package:fii_app/modules/reit_list/data/repositories/default_reit_list_settings_repository.dart';
 import 'package:fii_app/modules/reit_list/domain/entities/reit_list_sort_option.dart';
@@ -53,7 +54,7 @@ void main() {
           .thenAnswer((_) => Future.value(true));
 
       final save = await repository.saveEnabledLists(mockList);
-      expect(save, equals(true));
+      expect(save, equals(const Right(true)));
       verify(mockDatasource.saveEnabledLists(mockList));
     });
   });
@@ -88,7 +89,7 @@ void main() {
 
       final save = await repository.saveListLimit(mockLimit);
 
-      expect(save, equals(true));
+      expect(save, equals(const Right(true)));
       verify(mockDatasource.saveListLimit(mockLimit));
     });
   });

--- a/test/modules/reit_list/usecases/get_enabled_lists_test.mocks.dart
+++ b/test/modules/reit_list/usecases/get_enabled_lists_test.mocks.dart
@@ -2,12 +2,14 @@
 // in fii_app/test/modules/reit_list/usecases/get_enabled_lists_test.dart.
 // Do not manually edit this file.
 
-import 'dart:async' as _i3;
+import 'dart:async' as _i4;
 
+import 'package:dartz/dartz.dart' as _i2;
+import 'package:fii_app/core/errors/failures.dart' as _i6;
 import 'package:fii_app/modules/reit_list/domain/entities/reit_list_sort_option.dart'
-    as _i4;
+    as _i5;
 import 'package:fii_app/modules/reit_list/domain/repositories/reit_list_settings_repository.dart'
-    as _i2;
+    as _i3;
 import 'package:mockito/mockito.dart' as _i1;
 
 // ignore_for_file: avoid_redundant_argument_values
@@ -18,33 +20,40 @@ import 'package:mockito/mockito.dart' as _i1;
 // ignore_for_file: prefer_const_constructors
 // ignore_for_file: unnecessary_parenthesis
 
+class _FakeEither<L, R> extends _i1.Fake implements _i2.Either<L, R> {}
+
 /// A class which mocks [ReitListSettingsRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockReitListSettingsRepository extends _i1.Mock
-    implements _i2.ReitListSettingsRepository {
+    implements _i3.ReitListSettingsRepository {
   MockReitListSettingsRepository() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i3.Future<List<_i4.ReitListSortOptionType>> getEnabledLists() =>
+  _i4.Future<List<_i5.ReitListSortOptionType>> getEnabledLists() =>
       (super.noSuchMethod(Invocation.method(#getEnabledLists, []),
-              returnValue: Future<List<_i4.ReitListSortOptionType>>.value(
-                  <_i4.ReitListSortOptionType>[]))
-          as _i3.Future<List<_i4.ReitListSortOptionType>>);
+              returnValue: Future<List<_i5.ReitListSortOptionType>>.value(
+                  <_i5.ReitListSortOptionType>[]))
+          as _i4.Future<List<_i5.ReitListSortOptionType>>);
   @override
-  _i3.Future<bool> saveEnabledLists(List<_i4.ReitListSortOptionType>? lists) =>
+  _i4.Future<_i2.Either<_i6.Failure, bool>> saveEnabledLists(
+          List<_i5.ReitListSortOptionType>? lists) =>
       (super.noSuchMethod(Invocation.method(#saveEnabledLists, [lists]),
-          returnValue: Future<bool>.value(false)) as _i3.Future<bool>);
+              returnValue: Future<_i2.Either<_i6.Failure, bool>>.value(
+                  _FakeEither<_i6.Failure, bool>()))
+          as _i4.Future<_i2.Either<_i6.Failure, bool>>);
   @override
   int getListLimit() =>
       (super.noSuchMethod(Invocation.method(#getListLimit, []), returnValue: 0)
           as int);
   @override
-  _i3.Future<bool> saveListLimit(int? limit) =>
+  _i4.Future<_i2.Either<_i6.Failure, bool>> saveListLimit(int? limit) =>
       (super.noSuchMethod(Invocation.method(#saveListLimit, [limit]),
-          returnValue: Future<bool>.value(false)) as _i3.Future<bool>);
+              returnValue: Future<_i2.Either<_i6.Failure, bool>>.value(
+                  _FakeEither<_i6.Failure, bool>()))
+          as _i4.Future<_i2.Either<_i6.Failure, bool>>);
   @override
   String toString() => super.toString();
 }

--- a/test/modules/reit_list/usecases/get_list_limit_test.mocks.dart
+++ b/test/modules/reit_list/usecases/get_list_limit_test.mocks.dart
@@ -2,12 +2,14 @@
 // in fii_app/test/modules/reit_list/usecases/get_list_limit_test.dart.
 // Do not manually edit this file.
 
-import 'dart:async' as _i3;
+import 'dart:async' as _i4;
 
+import 'package:dartz/dartz.dart' as _i2;
+import 'package:fii_app/core/errors/failures.dart' as _i6;
 import 'package:fii_app/modules/reit_list/domain/entities/reit_list_sort_option.dart'
-    as _i4;
+    as _i5;
 import 'package:fii_app/modules/reit_list/domain/repositories/reit_list_settings_repository.dart'
-    as _i2;
+    as _i3;
 import 'package:mockito/mockito.dart' as _i1;
 
 // ignore_for_file: avoid_redundant_argument_values
@@ -18,33 +20,40 @@ import 'package:mockito/mockito.dart' as _i1;
 // ignore_for_file: prefer_const_constructors
 // ignore_for_file: unnecessary_parenthesis
 
+class _FakeEither<L, R> extends _i1.Fake implements _i2.Either<L, R> {}
+
 /// A class which mocks [ReitListSettingsRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockReitListSettingsRepository extends _i1.Mock
-    implements _i2.ReitListSettingsRepository {
+    implements _i3.ReitListSettingsRepository {
   MockReitListSettingsRepository() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i3.Future<List<_i4.ReitListSortOptionType>> getEnabledLists() =>
+  _i4.Future<List<_i5.ReitListSortOptionType>> getEnabledLists() =>
       (super.noSuchMethod(Invocation.method(#getEnabledLists, []),
-              returnValue: Future<List<_i4.ReitListSortOptionType>>.value(
-                  <_i4.ReitListSortOptionType>[]))
-          as _i3.Future<List<_i4.ReitListSortOptionType>>);
+              returnValue: Future<List<_i5.ReitListSortOptionType>>.value(
+                  <_i5.ReitListSortOptionType>[]))
+          as _i4.Future<List<_i5.ReitListSortOptionType>>);
   @override
-  _i3.Future<bool> saveEnabledLists(List<_i4.ReitListSortOptionType>? lists) =>
+  _i4.Future<_i2.Either<_i6.Failure, bool>> saveEnabledLists(
+          List<_i5.ReitListSortOptionType>? lists) =>
       (super.noSuchMethod(Invocation.method(#saveEnabledLists, [lists]),
-          returnValue: Future<bool>.value(false)) as _i3.Future<bool>);
+              returnValue: Future<_i2.Either<_i6.Failure, bool>>.value(
+                  _FakeEither<_i6.Failure, bool>()))
+          as _i4.Future<_i2.Either<_i6.Failure, bool>>);
   @override
   int getListLimit() =>
       (super.noSuchMethod(Invocation.method(#getListLimit, []), returnValue: 0)
           as int);
   @override
-  _i3.Future<bool> saveListLimit(int? limit) =>
+  _i4.Future<_i2.Either<_i6.Failure, bool>> saveListLimit(int? limit) =>
       (super.noSuchMethod(Invocation.method(#saveListLimit, [limit]),
-          returnValue: Future<bool>.value(false)) as _i3.Future<bool>);
+              returnValue: Future<_i2.Either<_i6.Failure, bool>>.value(
+                  _FakeEither<_i6.Failure, bool>()))
+          as _i4.Future<_i2.Either<_i6.Failure, bool>>);
   @override
   String toString() => super.toString();
 }

--- a/test/modules/reit_list/usecases/save_enabled_lists_test.dart
+++ b/test/modules/reit_list/usecases/save_enabled_lists_test.dart
@@ -24,7 +24,7 @@ void main() {
 
   test('should save enabled lists on the repository', () async {
     when(mockReitListSettingsRepository.saveEnabledLists(mockList))
-        .thenAnswer((_) => Future.value(true));
+        .thenAnswer((_) async => const Right(true));
 
     final lists = await usecase(mockList);
 
@@ -35,11 +35,11 @@ void main() {
 
   test('should return a Failure when repository fails to save list', () async {
     when(mockReitListSettingsRepository.saveEnabledLists(any))
-        .thenAnswer((_) => Future.value(false));
+        .thenAnswer((_) async => Left(Failure()));
 
     final lists = await usecase(mockList);
 
-    expect(lists, equals(Left(LocalStorageFailure())));
+    expect(lists, equals(Left(Failure())));
     verify(mockReitListSettingsRepository.saveEnabledLists(mockList));
     verifyNoMoreInteractions(mockReitListSettingsRepository);
   });

--- a/test/modules/reit_list/usecases/save_enabled_lists_test.mocks.dart
+++ b/test/modules/reit_list/usecases/save_enabled_lists_test.mocks.dart
@@ -2,12 +2,14 @@
 // in fii_app/test/modules/reit_list/usecases/save_enabled_lists_test.dart.
 // Do not manually edit this file.
 
-import 'dart:async' as _i3;
+import 'dart:async' as _i4;
 
+import 'package:dartz/dartz.dart' as _i2;
+import 'package:fii_app/core/errors/failures.dart' as _i6;
 import 'package:fii_app/modules/reit_list/domain/entities/reit_list_sort_option.dart'
-    as _i4;
+    as _i5;
 import 'package:fii_app/modules/reit_list/domain/repositories/reit_list_settings_repository.dart'
-    as _i2;
+    as _i3;
 import 'package:mockito/mockito.dart' as _i1;
 
 // ignore_for_file: avoid_redundant_argument_values
@@ -18,33 +20,40 @@ import 'package:mockito/mockito.dart' as _i1;
 // ignore_for_file: prefer_const_constructors
 // ignore_for_file: unnecessary_parenthesis
 
+class _FakeEither<L, R> extends _i1.Fake implements _i2.Either<L, R> {}
+
 /// A class which mocks [ReitListSettingsRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockReitListSettingsRepository extends _i1.Mock
-    implements _i2.ReitListSettingsRepository {
+    implements _i3.ReitListSettingsRepository {
   MockReitListSettingsRepository() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i3.Future<List<_i4.ReitListSortOptionType>> getEnabledLists() =>
+  _i4.Future<List<_i5.ReitListSortOptionType>> getEnabledLists() =>
       (super.noSuchMethod(Invocation.method(#getEnabledLists, []),
-              returnValue: Future<List<_i4.ReitListSortOptionType>>.value(
-                  <_i4.ReitListSortOptionType>[]))
-          as _i3.Future<List<_i4.ReitListSortOptionType>>);
+              returnValue: Future<List<_i5.ReitListSortOptionType>>.value(
+                  <_i5.ReitListSortOptionType>[]))
+          as _i4.Future<List<_i5.ReitListSortOptionType>>);
   @override
-  _i3.Future<bool> saveEnabledLists(List<_i4.ReitListSortOptionType>? lists) =>
+  _i4.Future<_i2.Either<_i6.Failure, bool>> saveEnabledLists(
+          List<_i5.ReitListSortOptionType>? lists) =>
       (super.noSuchMethod(Invocation.method(#saveEnabledLists, [lists]),
-          returnValue: Future<bool>.value(false)) as _i3.Future<bool>);
+              returnValue: Future<_i2.Either<_i6.Failure, bool>>.value(
+                  _FakeEither<_i6.Failure, bool>()))
+          as _i4.Future<_i2.Either<_i6.Failure, bool>>);
   @override
   int getListLimit() =>
       (super.noSuchMethod(Invocation.method(#getListLimit, []), returnValue: 0)
           as int);
   @override
-  _i3.Future<bool> saveListLimit(int? limit) =>
+  _i4.Future<_i2.Either<_i6.Failure, bool>> saveListLimit(int? limit) =>
       (super.noSuchMethod(Invocation.method(#saveListLimit, [limit]),
-          returnValue: Future<bool>.value(false)) as _i3.Future<bool>);
+              returnValue: Future<_i2.Either<_i6.Failure, bool>>.value(
+                  _FakeEither<_i6.Failure, bool>()))
+          as _i4.Future<_i2.Either<_i6.Failure, bool>>);
   @override
   String toString() => super.toString();
 }

--- a/test/modules/reit_list/usecases/save_list_limit_test.dart
+++ b/test/modules/reit_list/usecases/save_list_limit_test.dart
@@ -23,7 +23,7 @@ void main() {
 
   test('should save list limit on the repository', () async {
     when(mockReitListSettingsRepository.saveListLimit(mockLimit))
-        .thenAnswer((_) => Future.value(true));
+        .thenAnswer((_) async => const Right(true));
 
     final save = await usecase(mockLimit);
 
@@ -35,11 +35,11 @@ void main() {
   test('should return a Failure when repository fails to save list limit',
       () async {
     when(mockReitListSettingsRepository.saveListLimit(any))
-        .thenAnswer((_) => Future.value(false));
+        .thenAnswer((_) async => Left(Failure()));
 
     final lists = await usecase(mockLimit);
 
-    expect(lists, equals(Left(LocalStorageFailure())));
+    expect(lists, equals(Left(Failure())));
     verify(mockReitListSettingsRepository.saveListLimit(mockLimit));
     verifyNoMoreInteractions(mockReitListSettingsRepository);
   });

--- a/test/modules/reit_list/usecases/save_list_limit_test.mocks.dart
+++ b/test/modules/reit_list/usecases/save_list_limit_test.mocks.dart
@@ -2,12 +2,14 @@
 // in fii_app/test/modules/reit_list/usecases/save_list_limit_test.dart.
 // Do not manually edit this file.
 
-import 'dart:async' as _i3;
+import 'dart:async' as _i4;
 
+import 'package:dartz/dartz.dart' as _i2;
+import 'package:fii_app/core/errors/failures.dart' as _i6;
 import 'package:fii_app/modules/reit_list/domain/entities/reit_list_sort_option.dart'
-    as _i4;
+    as _i5;
 import 'package:fii_app/modules/reit_list/domain/repositories/reit_list_settings_repository.dart'
-    as _i2;
+    as _i3;
 import 'package:mockito/mockito.dart' as _i1;
 
 // ignore_for_file: avoid_redundant_argument_values
@@ -18,33 +20,40 @@ import 'package:mockito/mockito.dart' as _i1;
 // ignore_for_file: prefer_const_constructors
 // ignore_for_file: unnecessary_parenthesis
 
+class _FakeEither<L, R> extends _i1.Fake implements _i2.Either<L, R> {}
+
 /// A class which mocks [ReitListSettingsRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockReitListSettingsRepository extends _i1.Mock
-    implements _i2.ReitListSettingsRepository {
+    implements _i3.ReitListSettingsRepository {
   MockReitListSettingsRepository() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i3.Future<List<_i4.ReitListSortOptionType>> getEnabledLists() =>
+  _i4.Future<List<_i5.ReitListSortOptionType>> getEnabledLists() =>
       (super.noSuchMethod(Invocation.method(#getEnabledLists, []),
-              returnValue: Future<List<_i4.ReitListSortOptionType>>.value(
-                  <_i4.ReitListSortOptionType>[]))
-          as _i3.Future<List<_i4.ReitListSortOptionType>>);
+              returnValue: Future<List<_i5.ReitListSortOptionType>>.value(
+                  <_i5.ReitListSortOptionType>[]))
+          as _i4.Future<List<_i5.ReitListSortOptionType>>);
   @override
-  _i3.Future<bool> saveEnabledLists(List<_i4.ReitListSortOptionType>? lists) =>
+  _i4.Future<_i2.Either<_i6.Failure, bool>> saveEnabledLists(
+          List<_i5.ReitListSortOptionType>? lists) =>
       (super.noSuchMethod(Invocation.method(#saveEnabledLists, [lists]),
-          returnValue: Future<bool>.value(false)) as _i3.Future<bool>);
+              returnValue: Future<_i2.Either<_i6.Failure, bool>>.value(
+                  _FakeEither<_i6.Failure, bool>()))
+          as _i4.Future<_i2.Either<_i6.Failure, bool>>);
   @override
   int getListLimit() =>
       (super.noSuchMethod(Invocation.method(#getListLimit, []), returnValue: 0)
           as int);
   @override
-  _i3.Future<bool> saveListLimit(int? limit) =>
+  _i4.Future<_i2.Either<_i6.Failure, bool>> saveListLimit(int? limit) =>
       (super.noSuchMethod(Invocation.method(#saveListLimit, [limit]),
-          returnValue: Future<bool>.value(false)) as _i3.Future<bool>);
+              returnValue: Future<_i2.Either<_i6.Failure, bool>>.value(
+                  _FakeEither<_i6.Failure, bool>()))
+          as _i4.Future<_i2.Either<_i6.Failure, bool>>);
   @override
   String toString() => super.toString();
 }


### PR DESCRIPTION
- Parâmetro sortOptions foi movido do store de Reit List para store de Reit List Settings;
- Implementações de Repositories e Usecases refatoradas para melhorar tratamento de erro;