### PR TITLE
FA-66 - Refatorar filtros do Comparador para código reutilizável 

### DIFF
--- a/lib/core/presentation/models/reit_filter.dart
+++ b/lib/core/presentation/models/reit_filter.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+import '../../domain/entities/reit_column.dart';
+
+abstract class ReitSettingsFilter {
+  final ReitColumn column;
+  final bool Function() disable;
+  final void Function()? onToggle;
+
+  ReitSettingsFilter({
+    required this.column,
+    required this.disable,
+    this.onToggle,
+  });
+}
+
+class ReitSettingsInputFilter extends ReitSettingsFilter {
+  final String? prefix;
+  final String? suffix;
+  final TextInputType? keyboardType;
+  final int? maxLength;
+
+  final List<double?> Function() currentRange;
+  final void Function(double?, double?)? onChange;
+
+  ReitSettingsInputFilter({
+    required ReitColumn column,
+    void Function()? onToggle,
+    required bool Function() disable,
+    this.prefix,
+    this.suffix,
+    this.keyboardType,
+    this.maxLength,
+    required this.currentRange,
+    this.onChange,
+  }) : super(column: column, disable: disable, onToggle: onToggle);
+}
+
+class ReitSettingsSliderFilter extends ReitSettingsFilter {
+  final double Function() min;
+  final double Function() max;
+  final List<double> Function() currentRange;
+  final void Function(double, double)? onChange;
+
+  ReitSettingsSliderFilter({
+    required ReitColumn column,
+    void Function()? onToggle,
+    required bool Function() disable,
+    required this.min,
+    required this.max,
+    required this.currentRange,
+    this.onChange,
+  }) : super(column: column, disable: disable, onToggle: onToggle);
+}

--- a/lib/core/presentation/stores/comparator_store.dart
+++ b/lib/core/presentation/stores/comparator_store.dart
@@ -1,11 +1,10 @@
-import 'package:fii_app/core/domain/entities/reit.dart';
-import 'package:fii_app/core/domain/entities/reit_column.dart';
-import 'package:fii_app/core/presentation/stores/reit_list_store.dart';
 import 'package:mobx/mobx.dart';
 
-part 'comparator_store.g.dart';
+import '../../domain/entities/reit.dart';
+import '../../domain/entities/reit_column.dart';
+import 'reit_list_store.dart';
 
-enum ReitFilter { dividendYield, assetsAmount }
+part 'comparator_store.g.dart';
 
 class ComparatorStore = _ComparatorStoreBase with _$ComparatorStore;
 
@@ -17,7 +16,7 @@ abstract class _ComparatorStoreBase with Store {
 
   // Filters
   @observable
-  ObservableList<ReitFilter> enabledFilters = <ReitFilter>[].asObservable();
+  ObservableList<ReitColumn> enabledFilters = <ReitColumn>[].asObservable();
 
   @observable
   List<double?> dividendYieldRange = List.filled(2, null);
@@ -44,17 +43,17 @@ abstract class _ComparatorStoreBase with Store {
   ].asObservable();
 
   @observable
-  ObservableList<ReitColumnType> enabledColumns = [
-    ReitColumnType.sector,
-    ReitColumnType.currentPrice,
-    ReitColumnType.dailyLiquidity,
-    ReitColumnType.currentDividend,
-    ReitColumnType.currentDividendYield,
-    ReitColumnType.netWorth,
-    ReitColumnType.vpa,
-    ReitColumnType.pvpa,
-    ReitColumnType.vacancy,
-    ReitColumnType.assetsAmount
+  ObservableList<ReitColumn> enabledColumns = [
+    const ReitColumn(type: ReitColumnType.sector),
+    const ReitColumn(type: ReitColumnType.currentPrice),
+    const ReitColumn(type: ReitColumnType.dailyLiquidity),
+    const ReitColumn(type: ReitColumnType.currentDividend),
+    const ReitColumn(type: ReitColumnType.currentDividendYield),
+    const ReitColumn(type: ReitColumnType.netWorth),
+    const ReitColumn(type: ReitColumnType.vpa),
+    const ReitColumn(type: ReitColumnType.pvpa),
+    const ReitColumn(type: ReitColumnType.vacancy),
+    const ReitColumn(type: ReitColumnType.assetsAmount),
   ].asObservable();
 
   _ComparatorStoreBase({
@@ -74,7 +73,9 @@ abstract class _ComparatorStoreBase with Store {
   List<Reit> get currentReits {
     List<Reit> reits = textFilteredReits;
 
-    if (isFilterEnabled(ReitFilter.dividendYield)) {
+    if (isFilterEnabled(
+      const ReitColumn(type: ReitColumnType.currentDividendYield),
+    )) {
       final min = dividendYieldRange.first;
       final max = dividendYieldRange.last;
 
@@ -100,7 +101,9 @@ abstract class _ComparatorStoreBase with Store {
       }
     }
 
-    if (isFilterEnabled(ReitFilter.assetsAmount)) {
+    if (isFilterEnabled(
+      const ReitColumn(type: ReitColumnType.assetsAmount),
+    )) {
       reits = reits
           .where(
             (reit) =>
@@ -118,7 +121,7 @@ abstract class _ComparatorStoreBase with Store {
 
   // Filters
   @action
-  void toggleFilter(ReitFilter filter) {
+  void toggleFilter(ReitColumn filter) {
     if (enabledFilters.contains(filter)) {
       enabledFilters.remove(filter);
     } else {
@@ -126,7 +129,7 @@ abstract class _ComparatorStoreBase with Store {
     }
   }
 
-  bool isFilterEnabled(ReitFilter filter) => enabledFilters.contains(filter);
+  bool isFilterEnabled(ReitColumn filter) => enabledFilters.contains(filter);
 
   @computed
   int get minAssetsAmount =>
@@ -138,23 +141,19 @@ abstract class _ComparatorStoreBase with Store {
 
   // Columns
   @computed
-  List<ReitColumn> get enabledColumnsInOrder => tableColumns
-      .where((column) => enabledColumns.contains(column.type))
-      .toList();
+  List<ReitColumn> get enabledColumnsInOrder =>
+      tableColumns.where((column) => enabledColumns.contains(column)).toList();
 
   @action
   void toggleColumn(ReitColumn column) {
-    final type = column.type;
-
-    if (enabledColumns.contains(type)) {
+    if (enabledColumns.contains(column)) {
       if (enabledColumns.length > 1) {
-        enabledColumns.remove(type);
+        enabledColumns.remove(column);
       }
     } else {
-      enabledColumns.add(type);
+      enabledColumns.add(column);
     }
   }
 
-  bool isColumnEnabled(ReitColumn column) =>
-      enabledColumns.contains(column.type);
+  bool isColumnEnabled(ReitColumn column) => enabledColumns.contains(column);
 }

--- a/lib/core/presentation/stores/comparator_store.g.dart
+++ b/lib/core/presentation/stores/comparator_store.g.dart
@@ -72,13 +72,13 @@ mixin _$ComparatorStore on _ComparatorStoreBase, Store {
       Atom(name: '_ComparatorStoreBase.enabledFilters');
 
   @override
-  ObservableList<ReitFilter> get enabledFilters {
+  ObservableList<ReitColumn> get enabledFilters {
     _$enabledFiltersAtom.reportRead();
     return super.enabledFilters;
   }
 
   @override
-  set enabledFilters(ObservableList<ReitFilter> value) {
+  set enabledFilters(ObservableList<ReitColumn> value) {
     _$enabledFiltersAtom.reportWrite(value, super.enabledFilters, () {
       super.enabledFilters = value;
     });
@@ -135,13 +135,13 @@ mixin _$ComparatorStore on _ComparatorStoreBase, Store {
       Atom(name: '_ComparatorStoreBase.enabledColumns');
 
   @override
-  ObservableList<ReitColumnType> get enabledColumns {
+  ObservableList<ReitColumn> get enabledColumns {
     _$enabledColumnsAtom.reportRead();
     return super.enabledColumns;
   }
 
   @override
-  set enabledColumns(ObservableList<ReitColumnType> value) {
+  set enabledColumns(ObservableList<ReitColumn> value) {
     _$enabledColumnsAtom.reportWrite(value, super.enabledColumns, () {
       super.enabledColumns = value;
     });
@@ -151,7 +151,7 @@ mixin _$ComparatorStore on _ComparatorStoreBase, Store {
       ActionController(name: '_ComparatorStoreBase');
 
   @override
-  void toggleFilter(ReitFilter filter) {
+  void toggleFilter(ReitColumn filter) {
     final _$actionInfo = _$_ComparatorStoreBaseActionController.startAction(
         name: '_ComparatorStoreBase.toggleFilter');
     try {

--- a/lib/modules/comparator_settings/presentation/comparator_settings_page.dart
+++ b/lib/modules/comparator_settings/presentation/comparator_settings_page.dart
@@ -1,25 +1,19 @@
-import 'package:fii_app/core/navigation/navigator_service.dart';
-import 'package:fii_app/core/presentation/components/page_app_bar_component.dart';
-import 'package:fii_app/core/presentation/stores/comparator_store.dart';
-import 'package:fii_app/core/presentation/themes/app_colors.dart';
-import 'package:fii_app/core/presentation/themes/app_text_styles.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:get_it/get_it.dart';
 
-import 'components/range_input_filter_component.dart';
-import 'components/range_slider_filter_component.dart';
+import '../../../core/navigation/navigator_service.dart';
+import '../../../core/presentation/components/page_app_bar_component.dart';
+import '../../../core/presentation/stores/comparator_store.dart';
+import '../../../core/presentation/themes/app_colors.dart';
+import '../../../core/presentation/themes/app_text_styles.dart';
+import 'components/filter_list_component.dart';
 
 class ComparatorSettingsPage extends StatelessWidget {
   final navigatorService = GetIt.I.get<NavigatorService>().currentState!;
   final comparatorStore = GetIt.I.get<ComparatorStore>();
 
   ComparatorSettingsPage({Key? key}) : super(key: key);
-
-  static const Map<ReitFilter, String> filtersTitle = {
-    ReitFilter.dividendYield: "Dividend Yield",
-    ReitFilter.assetsAmount: "Número de ativos",
-  };
 
   void closePage() => navigatorService.pop();
 
@@ -67,43 +61,7 @@ class ComparatorSettingsPage extends StatelessWidget {
                   },
                 ),
                 const SizedBox(height: 12.0),
-                Observer(
-                  builder: (_) {
-                    const filter = ReitFilter.dividendYield;
-                    final disable = !comparatorStore.isFilterEnabled(filter);
-
-                    return RangeInputFilterComponent(
-                      title: filtersTitle[filter]!,
-                      currentRange: comparatorStore.dividendYieldRange,
-                      disable: disable,
-                      suffix: "%",
-                      keyboardType: TextInputType.number,
-                      maxLength: 6,
-                      onChange: (min, max) =>
-                          comparatorStore.dividendYieldRange = [min, max],
-                      onToggle: () => comparatorStore.toggleFilter(filter),
-                    );
-                  },
-                ),
-                Observer(
-                  builder: (_) {
-                    final min = comparatorStore.minAssetsAmount.toDouble();
-                    final max = comparatorStore.maxAssetsAmount.toDouble();
-                    const filter = ReitFilter.assetsAmount;
-                    final disable = !comparatorStore.isFilterEnabled(filter);
-
-                    return RangeSliderFilterComponent(
-                      title: filtersTitle[filter]!,
-                      min: min,
-                      max: max,
-                      disable: disable,
-                      currentRange: comparatorStore.assetsAmountRange,
-                      onChange: (min, max) =>
-                          comparatorStore.assetsAmountRange = [min, max],
-                      onToggle: () => comparatorStore.toggleFilter(filter),
-                    );
-                  },
-                ),
+                FilterListComponent(),
               ],
             ),
           ),

--- a/lib/modules/comparator_settings/presentation/components/filter_list_component.dart
+++ b/lib/modules/comparator_settings/presentation/components/filter_list_component.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
+import 'package:get_it/get_it.dart';
+
+import '../../../../core/domain/entities/reit_column.dart';
+import '../../../../core/presentation/models/reit_filter.dart';
+import '../../../../core/presentation/stores/comparator_store.dart';
+import 'range_input_filter_component.dart';
+import 'range_slider_filter_component.dart';
+
+class FilterListComponent extends StatelessWidget {
+  final comparatorStore = GetIt.I.get<ComparatorStore>();
+
+  late final List<ReitSettingsFilter> filters = [
+    ReitSettingsInputFilter(
+      column: const ReitColumn(type: ReitColumnType.currentDividendYield),
+      suffix: '%',
+      keyboardType: TextInputType.number,
+      maxLength: 6,
+      disable: () => !comparatorStore.isFilterEnabled(
+        const ReitColumn(
+          type: ReitColumnType.currentDividendYield,
+        ),
+      ),
+      currentRange: () => comparatorStore.dividendYieldRange,
+      onChange: (min, max) => comparatorStore.dividendYieldRange = [min, max],
+      onToggle: () => comparatorStore.toggleFilter(
+        const ReitColumn(
+          type: ReitColumnType.currentDividendYield,
+        ),
+      ),
+    ),
+    ReitSettingsSliderFilter(
+      column: const ReitColumn(type: ReitColumnType.assetsAmount),
+      min: () => comparatorStore.minAssetsAmount.toDouble(),
+      max: () => comparatorStore.maxAssetsAmount.toDouble(),
+      disable: () => !comparatorStore.isFilterEnabled(
+        const ReitColumn(
+          type: ReitColumnType.assetsAmount,
+        ),
+      ),
+      currentRange: () => comparatorStore.assetsAmountRange,
+      onChange: (min, max) => comparatorStore.assetsAmountRange = [min, max],
+      onToggle: () => comparatorStore.toggleFilter(
+        const ReitColumn(
+          type: ReitColumnType.assetsAmount,
+        ),
+      ),
+    ),
+  ];
+
+  FilterListComponent({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: filters
+          .map(
+            (filter) => Observer(
+              builder: (_) {
+                if (filter is ReitSettingsInputFilter) {
+                  return RangeInputFilterComponent(
+                    title: filter.column.label,
+                    suffix: filter.suffix,
+                    keyboardType: filter.keyboardType,
+                    maxLength: filter.maxLength,
+                    disable: filter.disable(),
+                    currentRange: filter.currentRange(),
+                    onChange: filter.onChange,
+                    onToggle: filter.onToggle,
+                  );
+                }
+
+                if (filter is ReitSettingsSliderFilter) {
+                  return RangeSliderFilterComponent(
+                    title: filter.column.label,
+                    min: filter.min(),
+                    max: filter.max(),
+                    disable: filter.disable(),
+                    currentRange: filter.currentRange(),
+                    onChange: filter.onChange,
+                    onToggle: filter.onToggle,
+                  );
+                }
+
+                return Container();
+              },
+            ),
+          )
+          .toList(),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.1"
+    version: "1.7.2"
   archive:
     dependency: transitive
     description:
@@ -35,7 +35,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -112,7 +112,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -414,7 +414,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   mime:
     dependency: transitive
     description:
@@ -671,7 +671,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.2"
   timing:
     dependency: transitive
     description:

--- a/test/modules/comparator/presentation/stores/comparator_store_test.dart
+++ b/test/modules/comparator/presentation/stores/comparator_store_test.dart
@@ -127,7 +127,7 @@ void main() {
     });
 
     group('dividend yield filter', () {
-      const filter = ReitFilter.dividendYield;
+      const filter = ReitColumn(type: ReitColumnType.currentDividendYield);
 
       test(
         'should return unfiltered reit list when filter is disabled',
@@ -193,7 +193,7 @@ void main() {
     });
 
     group('assets amount filter', () {
-      const filter = ReitFilter.assetsAmount;
+      const filter = ReitColumn(type: ReitColumnType.assetsAmount);
 
       test(
         'should return unfiltered reit list when filter is disabled',
@@ -229,7 +229,7 @@ void main() {
 
   group('toggleFilter', () {
     test('should enable a filter when the filter is disabled', () {
-      const mockFilter = ReitFilter.dividendYield;
+      const mockFilter = ReitColumn(type: ReitColumnType.currentDividendYield);
 
       store.toggleFilter(mockFilter);
 
@@ -237,7 +237,7 @@ void main() {
     });
 
     test('should disable a filter when the filter is enabled', () {
-      const mockFilter = ReitFilter.dividendYield;
+      const mockFilter = ReitColumn(type: ReitColumnType.currentDividendYield);
       store.enabledFilters.add(mockFilter);
 
       store.toggleFilter(mockFilter);
@@ -305,11 +305,11 @@ void main() {
   group('toggleColumn', () {
     test('should enable a column when the column is disabled', () {
       const mockColumn = ReitColumn(type: ReitColumnType.currentDividendYield);
-      store.enabledColumns.remove(mockColumn.type);
+      store.enabledColumns.remove(mockColumn);
 
       store.toggleColumn(mockColumn);
 
-      expect(store.enabledColumns, contains(mockColumn.type));
+      expect(store.enabledColumns, contains(mockColumn));
     });
 
     test('should disable a column when the column is enabled', () {


### PR DESCRIPTION
O código estava acoplado com cada filtro de tal forma que para adicionarmos novos filtros, teríamos muita duplicidade de código. Refatorei o Comparator Settings para que o código seja mais genérico, para evitar repetição.

Essa PR abre caminho para a criação de todos os filtros.